### PR TITLE
Remove dependency movement in development mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,8 +24,13 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 
+if (app.get('env') === 'development') {
+  app.use(express.static(path.join(__dirname, '../bower_components')));
+} else {
+  app.use(express.static(path.join(__dirname, 'bower_components')));
+}
+
 app.use(express.static(path.join(__dirname, 'public')));
-app.use(express.static(path.join(__dirname, 'bower_components')));
 
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,10 +11,8 @@ const gulp = require('gulp'),
 gulp.task('watch', function() {
     livereload.listen();
 
-    gulp.watch('./bower.json', ['moveBowerDependencies']);
-    gulp.watch('./package.json', ['moveNodeDependencies']);
     gulp.watch('public/stylesheets/*.scss', ['sassBuild']);
-    gulp.watch(['**/*.js', '!node_modules/**', '!build/**'], ['jsBuild']);
+    gulp.watch(['**/*.js', '!node_modules/**', '!bower_components/**', '!build/**'], ['jsBuild']);
     gulp.watch('views/**/*.jade', ['moveViews']);
 });
 
@@ -41,16 +39,6 @@ gulp.task('jsHint', function() {
         .pipe(jshint.reporter('default'));
 });
 
-gulp.task('moveNodeDependencies', function() {
-  return gulp.src('node_modules/**/*')
-     .pipe(gulp.dest('build/node_modules'));
-});
-
-gulp.task('moveBowerDependencies', function() {
-  return gulp.src('bower_components/**/*')
-    .pipe(gulp.dest('build/bower_components'));
-});
-
 gulp.task('moveViews', function() {
     return gulp.src('views/**/*.jade')
         .pipe(cache('moveViews'))
@@ -72,18 +60,27 @@ gulp.task('jsBuild', function() {
 });
 
 gulp.task('imgMove', function() {
-  return gulp.src('public/images/**/*')
-    .pipe(cache('imgMove'))
-    .pipe(gulp.dest('build/public/images'));
+    return gulp.src('public/images/**/*')
+        .pipe(cache('imgMove'))
+        .pipe(gulp.dest('build/public/images'));
 });
 
 gulp.task('clean', function(callback) {
     cache.caches = {};
-    return del(['build/**/*', '!node_modules/**', '!bower_components/**'], callback);
+    return del(['build/**/*'], callback);
 });
 
 gulp.task('build', function(callback) {
     return runSequence('clean', ['jsBuild', 'sassBuild', 'imgMove', 'moveViews'], callback);
+});
+
+gulp.task('productionBuild', function(callback) {
+    return runSequence('build', 'moveDependencies', callback);
+});
+
+gulp.task('moveDependencies', function(callback) {
+    return gulp.src(['node_modules/**/*', 'bower_components/**/*'], {base: './'})
+        .pipe(gulp.dest('build'));
 });
 
 gulp.task('develop', function(callback) {


### PR DESCRIPTION
@mok4ry 

Two types of third party dependencies that we really shouldn't be worrying about in dev mode: bower and node. Bower deps are now proxied to in development node, and node modules are automatically found since node keeps searching higher directories.
