### PR TITLE
Support for Jasmine CLI and Jasmine module

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ const gulp = require('gulp'),
     jasmineConfig = require('./spec/support/jasmine.json');
 
 gulp.task('test', function() {
-    jasmineRunner = new Jasmine();
+    const jasmineRunner = new Jasmine();
     jasmineRunner.loadConfig(jasmineConfig);
     jasmineRunner.execute();
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,15 @@ const gulp = require('gulp'),
     del = require('del'),
     runSequence = require('run-sequence'),
     cache = require('gulp-cached'),
-    jshint = require('gulp-jshint');
+    jshint = require('gulp-jshint'),
+    Jasmine = require('jasmine'),
+    jasmineConfig = require('./spec/support/jasmine.json');
+
+gulp.task('test', function() {
+    jasmineRunner = new Jasmine();
+    jasmineRunner.loadConfig(jasmineConfig);
+    jasmineRunner.execute();
+});
 
 gulp.task('watch', function() {
     livereload.listen();
@@ -21,7 +29,7 @@ gulp.task('liveResetting', function() {
         script: 'build/bin/www',
         ext: 'js jade css',
         watch: ['build/'],
-        stdout: false 
+        stdout: false
     }).on('readable', function () {
         this.stdout.on('data', function (chunk) {
             if(/^Express server listening on port/.test(chunk)){

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp-livereload": "^3.8.1",
     "gulp-nodemon": "^2.0.4",
     "gulp-sass": "^2.0.4",
+    "jasmine": "^2.4.1",
     "run-sequence": "^1.1.4"
   }
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "build/spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
Unit testing boilerplate for ES6 JS. The configuration always points to the build, nothing else.. so you can run `jasmine` as a command like you normally would if it is globally installed. If not, that's fine.. I added a simple gulp task (`gulp test`) that encapsulates the jasmine module itself as well. so there's literally no excuse to not unit test ;) 

This is tested against actual unit tests I'll be pushing btw

@mok4ry @Lettuceman44 
