### PR TITLE
Figshare id l1

### DIFF
--- a/lib/repository-mappers/figshare/parseL1ArticlePresenters.js
+++ b/lib/repository-mappers/figshare/parseL1ArticlePresenters.js
@@ -2,6 +2,7 @@ import { map } from 'lodash';
 
 function parseL1ArticlePresenter(article) {
   return {
+    id: article.id,
     identifier: article.doi,
     datePublished: article.published_date,
     title: article.title,

--- a/spec/lib/repository-mappers/figshare/parseL1ArticlePresenters-spec.js
+++ b/spec/lib/repository-mappers/figshare/parseL1ArticlePresenters-spec.js
@@ -7,6 +7,11 @@ it('parses all articles figshare returns', () =>
   expect(convertedArticles.length).toBe(2)
 );
 
+it('parses Figshare article IDs', () => {
+  expect(convertedArticles[0].id).toBe(figshareL1Articles[0].id);
+  expect(convertedArticles[1].id).toBe(figshareL1Articles[1].id);
+});
+
 it('converts Figshare article DOIs to codemeta identifier', () => {
   expect(convertedArticles[0].identifier).toBe(figshareL1Articles[0].doi);
   expect(convertedArticles[1].identifier).toBe(figshareL1Articles[1].doi);


### PR DESCRIPTION
Add figshare's specific ID to the L1 presenter returned to the client. It's not part of the Json-ld schema, but it's needed to we can actually pull the L2 presenter.  @mok4ry 
