### PR TITLE
Update figshare post body

### DIFF
--- a/lib/repository-clients/figshare-client.js
+++ b/lib/repository-clients/figshare-client.js
@@ -4,21 +4,25 @@ import { format as strFormat } from 'util';
 const searchUrl = 'http://api.figshare.com/v2/articles/search';
 const l2ArticleUrl = 'https://api.figshare.com/v2/articles/%s';
 
-export function searchFigshare(search_for, page) {
-  page = page || 1;
-  return new Promise((resolve, reject) => (
+export function searchFigshare(searchFor, pageNum) {
+  return new Promise((resolve, reject) => {
+    const postPayload = {
+      search_for: searchFor,
+      page: pageNum || 1,
+    };
+
     post({
-        url: searchUrl,
-        body: { search_for, page },
-        json: true,
+      url: searchUrl,
+      body: postPayload,
+      json: true,
     }, (error, response, body) => {
       if (response.statusCode === 200) resolve(body);
       if (error) reject(error);
       const errMsg = strFormat('Unable to perform Figshare search: (%d), "%s"',
         response.statusCode, response.body.message);
       reject(new Error(errMsg));
-    })
-  ));
+    });
+  });
 }
 
 export function getL2Article(id) {

--- a/lib/repository-clients/figshare-client.js
+++ b/lib/repository-clients/figshare-client.js
@@ -4,11 +4,12 @@ import { format as strFormat } from 'util';
 const searchUrl = 'http://api.figshare.com/v2/articles/search';
 const l2ArticleUrl = 'https://api.figshare.com/v2/articles/%s';
 
-export function searchFigshare(search_for, pageNumber) {
+export function searchFigshare(search_for, page) {
+  page = page || 1;
   return new Promise((resolve, reject) => (
     post({
         url: searchUrl,
-        qs: { search_for },
+        body: { search_for, page },
         json: true,
     }, (error, response, body) => {
       if (response.statusCode === 200) resolve(body);

--- a/lib/routes/figshare.js
+++ b/lib/routes/figshare.js
@@ -11,8 +11,8 @@ const router = express.Router(); // eslint-disable-line new-cap
 router.get('/search', (req, res, next) => {
   const jsonLdQuery = parseJsonLdQueryParams(req.query);
   if (!isEmpty(jsonLdQuery)) {
-    const search_for = flatten(flatMap(jsonLdQuery)).join(' ');
-    searchFigshare(search_for, parseInt(req.query.page)).then((articles) => {
+    const searchFor = flatten(flatMap(jsonLdQuery)).join(' ');
+    searchFigshare(searchFor, parseInt(req.query.page, 10)).then((articles) => {
       const parsedArticles = parseL1ArticlePresenters(articles);
       res.send(parsedArticles);
     }).catch(err => {

--- a/lib/routes/figshare.js
+++ b/lib/routes/figshare.js
@@ -11,8 +11,8 @@ const router = express.Router(); // eslint-disable-line new-cap
 router.get('/search', (req, res, next) => {
   const jsonLdQuery = parseJsonLdQueryParams(req.query);
   if (!isEmpty(jsonLdQuery)) {
-    const searchFor = flatten(flatMap(jsonLdQuery)).join(' ');
-    searchFigshare(searchFor).then((articles) => {
+    const search_for = flatten(flatMap(jsonLdQuery)).join(' ');
+    searchFigshare(search_for, parseInt(req.query.page)).then((articles) => {
       const parsedArticles = parseL1ArticlePresenters(articles);
       res.send(parsedArticles);
     }).catch(err => {


### PR DESCRIPTION
Query params for searching figshare belong in the POST payload now, not the query string as they once did. Also, support pagination.

@mok4ry  @amb8805 
