### PR TITLE
GitHub support via DataCite [W.I.P]

### DIFF
--- a/lib/repository-clients/datacite-client.js
+++ b/lib/repository-clients/datacite-client.js
@@ -1,13 +1,21 @@
 import { get } from 'request';
 import { format as strFormat } from 'util';
 
-const searchUrl = 'http://search.datacite.org/api?wt=json&q=';
+const searchUrl = 'http://search.datacite.org/api';
+const softwareFilterQuery = 'resourceTypeGeneral:Software';
 
-export function searchDatacite(q) {
+export function searchDatacite(query, filterQuery, pageNum) {
   return new Promise((resolve, reject) => (
     get({
-      url: strFormat(searchUrl, q),
+      url: searchUrl,
+      useQuerystring: true,
       json: true,
+      qs: {
+        q: query,
+        fq: filterQuery.concat([softwareFilterQuery]),
+        start: pageNum >= 1 ? (pageNum - 1) * 10 : 0,
+        wt: 'json',
+      },
     }, (error, response, body) => {
       if (response.statusCode === 200) resolve(body);
       if (error) reject(error);

--- a/lib/routes/github.js
+++ b/lib/routes/github.js
@@ -14,10 +14,9 @@ router.get('/search', (req, res, next) => {
     const searchFor = flatten(flatMap(jsonLdQuery)).join(' ');
 
     let pageNum = parseInt(req.query.page, 10);
-    if (!pageNum || pageNum < 1) {
-      pageNum = 1;
-    }
-    searchDatacite(searchFor, pageNum).then((repos) => {
+    if (!pageNum || pageNum < 1) pageNum = 1;
+
+    searchDatacite(searchFor, ['relatedIdentifier:*github*'], pageNum).then((repos) => {
       res.send({
         parsedArticles: parseRepositories(repos.response.docs),
         responseHeader: {
@@ -26,12 +25,12 @@ router.get('/search', (req, res, next) => {
         },
       });
     }).catch(err => {
-      console.error('Error occured searching  for "%s"', searchFor, err);
+      console.error('Error occured searching for "%s"', searchFor, err);
       next(err);
     });
   } else {
     const err = new Error(strFormat('Query parameters %j not valid for ' +
-      'datacite search', req.query));
+      'GitHub search', req.query));
     err.status = 422;
     console.error(err.message);
     next(err);

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import figshareRoute from './routes/figshare';
 import dataOneRoute from './routes/dataone';
-import dataciteRoute from './routes/datacite';
+import githubRoute from './routes/github';
 
 import {
   notFoundError,
@@ -20,7 +20,7 @@ app.use(bowerComponents);
 // Router middleware
 app.use('/figshare', figshareRoute);
 app.use('/dataone', dataOneRoute);
-app.use('/datacite', dataciteRoute);
+app.use('/github', githubRoute);
 
 // error handeling middleware
 app.use(notFoundError);

--- a/public/javascripts/constants.js
+++ b/public/javascripts/constants.js
@@ -22,7 +22,7 @@ const DATE_ATTR_DISPLAY = {
 const SUPPORTED_REPOS = [
   'FigShare',
   'DataONE',
-  'DataCite',
+  'GitHub',
 ];
 
 export {

--- a/public/javascripts/reducers/repoFilters.js
+++ b/public/javascripts/reducers/repoFilters.js
@@ -3,7 +3,6 @@ import { SELECT_REPO, DESELECT_REPO } from '../actions/repoFilter';
 export default function repoFilter(state = {}, action) {
   // TODO temporary until querying over multiple sources is supported
   const allDeselected = {
-    DataCite: false,
     GitHub: false,
     DataONE: false,
     BitBucket: false,

--- a/public/javascripts/store.js
+++ b/public/javascripts/store.js
@@ -4,7 +4,6 @@ import thunk from 'redux-thunk';
 
 const INITIAL_STATE = {
   repoFilters: {
-    DataCite: false,
     GitHub: false,
     DataONE: true,
     BitBucket: false,


### PR DESCRIPTION
This PR removes the DataCite search (as it is seen from the client), and masks it as a GitHub search. Under the hood, it is actually just searching datacite with [advanced criteria](https://github.com/mozillascience/software-discovery-dashboard/issues/71) to return GitHub results. Pretty cool, huh?

TODO: general cleanup, make sure everything necessary is refactored to github from datacite. clean up links to go to GitHub, as I think that's expected functionality.
