### PR TITLE
fix awkward spacing of keywords when article has no description

### DIFF
--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -101,7 +101,7 @@ a {
     line-height: 1.3em;
     max-height: 5.2em; 
     text-align: justify;  
-    margin-right: -1em;
+    margin: 0 -1em 0 0;
     padding-right: 1em;
   }
   .result-description:before {
@@ -141,7 +141,7 @@ a {
     }
     &.keywords-list{
       margin-left:-45px;
-      margin-top:-15px;
+      margin-top:-6px;
       float:left;
       margin-bottom:25px;
       li{


### PR DESCRIPTION
Issue #85 
