### PR TITLE
Correcting the markdown in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Software Discovery Dashboard
 
-###Synopsis
+## Synopsis
 
 >This project’s objective is to create an open source web dashboard capable of searching multiple code hosting services, such as Zenodo, Figshare, and GitHub, for the benefit of the research community. The goal of this dashboard is to demonstrate the usefulness of a [new metadata standard](https://github.com/mbjones/codemeta) by utilizing it for easy and effective software discovery and analysis.
 
-##Links
+## Links
 [Google Docs](https://drive.google.com/folderview?id=0B_kNLNI7Rky0fl9hZE9xZF9GV3FVSHVqdjVSV0tONDhlV2JRcWhEZWx3cDdQaXpNY2U1SEk&usp=sharing)
 
 [EtherPad](https://public.etherpad-mozilla.org/p/sciencelab-sdd)
 
 [Team Website](http://mozillascience.github.io/software-discovery-dashboard/)
 
-##Getting started
+## Getting started
 
 To run the Software Discovery Dashboard locally, run these steps:
 
@@ -24,17 +24,17 @@ This project follows the [Airbnb Style Guide](https://github.com/airbnb/javascri
 Included is a linter configured to enforce this style guide. It is run alongside
 unit tests with `npm test` but can also be run alone with `gulp lint`.
 
-##Communication
+## Communication
 Join the conversation on [Gitter](https://gitter.im/mozillascience/SoftwareDiscoveryDashboard).
 
-##Contributing
+## Contributing
 There are multiple ways to get involved in the project: open an issue, comment on open issues, join the conversation on Gitter (see Communication above), or fix an open issue, to name a few.
 
 Issues marked with the `help wanted` tag are a great place to start. They are smaller, generally straightforward bugs or
 enhancements meant to provide an easy introduction to the codebase while still contributing meaningful work. They may also be
 conversational issues where input is greatly appreciated.
 
-##Project Leadership
+## Project Leadership
 Technical Lead : Luke Coy
 
 QA Lead : Matt Mokary


### PR DESCRIPTION
This is a fix for https://github.com/mozillascience/software-discovery-dashboard/issues/111

The markdown in the below sections of the document have been updated so that the markdown has the desired effect:
* Synopsis
* Links
* Communication
* Contributing
* Project